### PR TITLE
Rename influxUrlBase in example config

### DIFF
--- a/ruuvi-collector.properties.example
+++ b/ruuvi-collector.properties.example
@@ -3,7 +3,7 @@
 # uncomment the lines and change the values, if you need
 
 # Base url to connect to, including protocol, hostname or ip address, and port
-#influxUrlBase=http://localhost:8086
+#influxUrl=http://localhost:8086
 
 # InfluxDB Database to use for measurements
 #influxDatabase=ruuvi


### PR DESCRIPTION
Noticed that as part of the 0.2 update, `influxUrlBase` got renamed internally, but the example config missed off this change.