### PR TITLE
Config tests fix

### DIFF
--- a/src/test/java/fi/tkgwf/ruuvi/MainTest.java
+++ b/src/test/java/fi/tkgwf/ruuvi/MainTest.java
@@ -2,8 +2,10 @@ package fi.tkgwf.ruuvi;
 
 import fi.tkgwf.ruuvi.bean.RuuviMeasurement;
 import fi.tkgwf.ruuvi.config.Config;
+import fi.tkgwf.ruuvi.config.ConfigTest;
 import fi.tkgwf.ruuvi.db.DBConnection;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
@@ -19,8 +21,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MainTest {
 
+    @BeforeEach
+    void resetConfigBefore() {
+        Config.reload(ConfigTest.configTestFileFinder());
+    }
+
     @AfterAll
     static void restoreClock() {
+        Config.reload(ConfigTest.configTestFileFinder());
         TestFixture.setClockToMilliseconds(System::currentTimeMillis);
     }
 

--- a/src/test/java/fi/tkgwf/ruuvi/PersistenceServiceTest.java
+++ b/src/test/java/fi/tkgwf/ruuvi/PersistenceServiceTest.java
@@ -3,6 +3,7 @@ package fi.tkgwf.ruuvi;
 import fi.tkgwf.ruuvi.bean.HCIData;
 import fi.tkgwf.ruuvi.bean.RuuviMeasurement;
 import fi.tkgwf.ruuvi.config.Config;
+import fi.tkgwf.ruuvi.config.ConfigTest;
 import fi.tkgwf.ruuvi.handler.impl.DataFormatV3;
 import fi.tkgwf.ruuvi.strategy.LimitingStrategy;
 import fi.tkgwf.ruuvi.utils.HCIParser;
@@ -21,12 +22,12 @@ class PersistenceServiceTest {
 
     @BeforeEach
     void resetConfigBefore() {
-        Config.reload();
+        Config.reload(ConfigTest.configTestFileFinder());
     }
 
     @AfterAll
     static void resetConfigAfter() {
-        Config.reload();
+        Config.reload(ConfigTest.configTestFileFinder());
     }
 
     @Test

--- a/src/test/java/fi/tkgwf/ruuvi/config/ConfigTest.java
+++ b/src/test/java/fi/tkgwf/ruuvi/config/ConfigTest.java
@@ -6,7 +6,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.net.URISyntaxException;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -15,16 +19,29 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-class ConfigTest {
+public class ConfigTest {
+
+    public static Function<String, File> configTestFileFinder() {
+        return propertiesFileName -> Optional.ofNullable(Config.class.getResource(String.format("/%s", propertiesFileName)))
+            .map(url -> {
+                try {
+                    return url.toURI();
+                } catch (final URISyntaxException e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .map(File::new)
+            .orElse(null);
+    }
 
     @BeforeEach
     void resetConfigBefore() {
-        Config.reload();
+        Config.reload(configTestFileFinder());
     }
 
     @AfterAll
     static void resetConfigAfter() {
-        Config.reload();
+        Config.reload(configTestFileFinder());
     }
 
     @Test

--- a/src/test/java/fi/tkgwf/ruuvi/handler/impl/DataFormatV3Test.java
+++ b/src/test/java/fi/tkgwf/ruuvi/handler/impl/DataFormatV3Test.java
@@ -3,13 +3,28 @@ package fi.tkgwf.ruuvi.handler.impl;
 import fi.tkgwf.ruuvi.TestFixture;
 import fi.tkgwf.ruuvi.bean.HCIData;
 import fi.tkgwf.ruuvi.bean.RuuviMeasurement;
+import fi.tkgwf.ruuvi.config.Config;
+import fi.tkgwf.ruuvi.config.ConfigTest;
 import fi.tkgwf.ruuvi.utils.HCIParser;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DataFormatV3Test {
+
+    @BeforeEach
+    void resetConfigBefore() {
+        Config.reload(ConfigTest.configTestFileFinder());
+    }
+
+    @AfterAll
+    static void resetConfigAfter() {
+        Config.reload(ConfigTest.configTestFileFinder());
+    }
+
     @Test
     void testThatHcidumpMessageOfDataFormatV3IsParsedCorrectly() {
         final RuuviMeasurement expected = new RuuviMeasurement();

--- a/src/test/java/fi/tkgwf/ruuvi/strategy/impl/DefaultDiscardingWithMotionSensitivityStrategyTest.java
+++ b/src/test/java/fi/tkgwf/ruuvi/strategy/impl/DefaultDiscardingWithMotionSensitivityStrategyTest.java
@@ -1,12 +1,27 @@
 package fi.tkgwf.ruuvi.strategy.impl;
 
 import fi.tkgwf.ruuvi.bean.RuuviMeasurement;
+import fi.tkgwf.ruuvi.config.Config;
+import fi.tkgwf.ruuvi.config.ConfigTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DefaultDiscardingWithMotionSensitivityStrategyTest {
+
+    @BeforeEach
+    void resetConfigBefore() {
+        Config.reload(ConfigTest.configTestFileFinder());
+    }
+
+    @AfterAll
+    static void resetConfigAfter() {
+        Config.reload(ConfigTest.configTestFileFinder());
+    }
+
     @Test
     void testMotionSensitivity() {
         final DefaultDiscardingWithMotionSensitivityStrategy strategy = new DefaultDiscardingWithMotionSensitivityStrategy();

--- a/src/test/java/fi/tkgwf/ruuvi/strategy/impl/DiscardUntilEnoughTimeHasElapsedStrategyTest.java
+++ b/src/test/java/fi/tkgwf/ruuvi/strategy/impl/DiscardUntilEnoughTimeHasElapsedStrategyTest.java
@@ -3,15 +3,28 @@ package fi.tkgwf.ruuvi.strategy.impl;
 import fi.tkgwf.ruuvi.TestFixture;
 import fi.tkgwf.ruuvi.bean.HCIData;
 import fi.tkgwf.ruuvi.bean.RuuviMeasurement;
+import fi.tkgwf.ruuvi.config.Config;
+import fi.tkgwf.ruuvi.config.ConfigTest;
 import fi.tkgwf.ruuvi.handler.impl.DataFormatV3;
 import fi.tkgwf.ruuvi.utils.HCIParser;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DiscardUntilEnoughTimeHasElapsedStrategyTest {
+
+    @BeforeEach
+    void resetConfigBefore() {
+        Config.reload(ConfigTest.configTestFileFinder());
+    }
+
+    @AfterAll
+    static void resetConfigAfter() {
+        Config.reload(ConfigTest.configTestFileFinder());
+    }
 
     @AfterAll
     static void restoreClock() {

--- a/src/test/java/fi/tkgwf/ruuvi/utils/InfluxDBConverterTest.java
+++ b/src/test/java/fi/tkgwf/ruuvi/utils/InfluxDBConverterTest.java
@@ -2,6 +2,7 @@ package fi.tkgwf.ruuvi.utils;
 
 import fi.tkgwf.ruuvi.bean.RuuviMeasurement;
 import fi.tkgwf.ruuvi.config.Config;
+import fi.tkgwf.ruuvi.config.ConfigTest;
 import org.influxdb.dto.Point;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,12 +22,12 @@ class InfluxDBConverterTest {
 
     @BeforeEach
     void resetConfigBefore() {
-        Config.reload();
+        Config.reload(ConfigTest.configTestFileFinder());
     }
 
     @AfterAll
     static void resetConfigAfter() {
-        Config.reload();
+        Config.reload(ConfigTest.configTestFileFinder());
     }
 
     @Test


### PR DESCRIPTION
Re: Issue #15

The Config class used to always search for the properties files from the project root. I made the file locator part customizable, and now the tests inject such a locator that finds the correct test files.