### PR TITLE
Ignore ruuvi-*.properties only in root folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 target/
-ruuvi-collector.properties
-ruuvi-names.properties
+/ruuvi-collector.properties
+/ruuvi-names.properties
 .idea/
 *.iml
 .settings/org.eclipse.m2e.core.prefs


### PR DESCRIPTION
ruuvi-collector.properties and ruuvi-names.properties files in the root
folder should be ignored as they are user configuration files created
based on the *.properties.example files.

In January 2019 in commit f452981 files with those same names were added
under src/test/resources/ directory to be used as part of the tests.
However, the .gitignore file was not altered back then to reflect that
those new files should not be ignored by git.

This commit updates the .gitignore to only ignore
ruuvi-collector.properties and ruuvi-names.properties files in the root
directory of the repository.