### PR TITLE
Adds a Prometheus backend

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
 
     <properties>
         <jdk.version>1.8</jdk.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <repositories>
@@ -27,19 +28,19 @@
             <artifactId>ruuvitag-common</artifactId>
             <version>1.0.1</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.8.1</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
             <version>4.2</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
@@ -65,6 +66,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.9.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_httpserver</artifactId>
+            <version>0.9.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>5.3.2</version>
@@ -78,7 +91,7 @@
                 <directory>src/main/resources</directory>
             </resource>
         </resources>
-        
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/ruuvi-collector.properties.example
+++ b/ruuvi-collector.properties.example
@@ -32,7 +32,7 @@
 #limitingStrategy.defaultWithMotionSensitivity.threshold=0.05
 
 # Filtering for sources based on the source MAC address (blacklist or whitelist)
-# Valid values "none", "blacklist" and "whitelist". 
+# Valid values "none", "blacklist" and "whitelist".
 # none      = Allows any source to be stored (default)
 # blacklist = Allows all sources EXCEPT those listed
 # whitelist = Allows ONLY sources that are listed in filter.macs
@@ -42,7 +42,7 @@
 # Mac addresses to blacklist/whitelist. This has no effect if filter.mode is set to none
 #filter.macs=ABCDEF012345,F1E2D3C4B5A6
 
-# Storage method, currently valid values: "influxdb", "legacy_influxdb" and "dummy"
+# Storage method, currently valid values: "influxdb", "legacy_influxdb", "prometheus" and "dummy"
 # influxdb        = Recommended and default, this stores the values to InfluxDB into a single measurement
 # influxdb_legacy = The old format used by this collector on versions before 0.2.0, stores values into separate measurements.
 #                   NOTE: influxdb_legacy is no longer supported, you should use the new influxdb format and migrate old data, see CHANGELOG.md

--- a/src/main/java/fi/tkgwf/ruuvi/db/PrometheusExporter.java
+++ b/src/main/java/fi/tkgwf/ruuvi/db/PrometheusExporter.java
@@ -1,0 +1,130 @@
+package fi.tkgwf.ruuvi.db;
+
+import fi.tkgwf.ruuvi.Main;
+import fi.tkgwf.ruuvi.bean.EnhancedRuuviMeasurement;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.SimpleCollector;
+import io.prometheus.client.exporter.HTTPServer;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * An exporter that writes measurements to Prometheus counters, exposed in the normal way over HTTP.
+ */
+public final class PrometheusExporter implements DBConnection {
+
+    private static final Logger LOG = Logger.getLogger(Main.class);
+
+    private static final String NAMESPACE = "ruuvi";
+    private static final String TAG_MAC_LABEL = "tag_mac";
+    private static final String TAG_NAME_LABEL = "tag_name";
+    private static final String DATA_FORMAT_LABEL = "data_format";
+
+    private final HTTPServer httpServer;
+
+    // metadata
+    private final Counter prometheusExportedCount = buildGauge("prometheus_exported",
+        "The number of readings written to Prometheus collectors", Counter.build());
+
+    // normal ones
+    private final Gauge rssi = buildGauge("rssi", "The RSSI at the receiver", Gauge.build());
+    private final Gauge temperature = buildGauge("temperature", "Temperature in Celsius", Gauge.build());
+    private final Gauge humidity = buildGauge("humidity", "Relative humidity in percentage (0-100)", Gauge.build());
+    private final Gauge pressure = buildGauge("pressure", "Pressure in Pa", Gauge.build());
+    private final Gauge accelerationX = buildGauge("acceleration_x", "Acceleration of X axis in G", Gauge.build());
+    private final Gauge accelerationY = buildGauge("acceleration_y", "Acceleration of Y axis in G", Gauge.build());
+    private final Gauge accelerationZ = buildGauge("acceleration_z", "Acceleration of Z axis in G", Gauge.build());
+    private final Gauge batteryVoltage = buildGauge("battery_voltage", "Battery voltage in Volts", Gauge.build());
+    private final Gauge txPower = buildGauge("tx_power", "TX power in dBm", Gauge.build());
+    private final Counter movementCounter = buildGauge("movement_counter", "Movement counter (incremented by interrupts from the accelerometer)", Counter.build());
+    private final Counter measurementSequenceNumber = buildGauge("measurement_sequence_number",
+        "Measurement sequence number (incremented every time a new measurement is made). Useful for measurement de-duplication.", Counter.build());
+
+    // "enhanced" ones
+    private final Gauge accelerationTotal = buildGauge("acceleration_total", "Total acceleration", Gauge.build());
+    private final Gauge accelerationAngleFromX = buildGauge("acceleration_angle_from_x", "The angle between the acceleration vector and X axis", Gauge.build());
+    private final Gauge accelerationAngleFromY = buildGauge("acceleration_angle_from_y", "The angle between the acceleration vector and Y axis", Gauge.build());
+    private final Gauge accelerationAngleFromZ = buildGauge("acceleration_angle_fromz", "The angle between the acceleration vector and Z axis", Gauge.build());
+    private final Gauge absoluteHumidity = buildGauge("absolute_humidity", "Absolute humidity in g/m^3", Gauge.build());
+    private final Gauge dewPoint = buildGauge("dew_point", "Dew point in Celsius", Gauge.build());
+    private final Gauge equilibriumVaporPressure = buildGauge("equilibrium_vapor_pressure", "Vapor pressure of water", Gauge.build());
+    private final Gauge airDensity = buildGauge("air_density", "Density of air", Gauge.build());
+
+    private final Gauge lastUpdate = buildGauge("last_update",
+        "Time at which the last update was collected for this measurement", Gauge.build());
+
+    public PrometheusExporter(int port) {
+        LOG.debug("Initialising PrometheusExporter, serving metrics on port " + port);
+        try {
+            httpServer = new HTTPServer(port);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to start Prometheus exporter HTTP server", e);
+        }
+    }
+
+    @SuppressWarnings("rawtypes") // SimpleCollector must be raw to satisfy the Builder<B, C> signature
+    private static <C extends SimpleCollector, B extends SimpleCollector.Builder<B, C>> C buildGauge(String name, String helpText, B builder) {
+        return builder
+            .namespace(NAMESPACE)
+            .name(name)
+            .help(helpText)
+            .labelNames(TAG_MAC_LABEL, TAG_NAME_LABEL, DATA_FORMAT_LABEL)
+            .create()
+            .register();
+    }
+
+    @Override
+    public void save(EnhancedRuuviMeasurement measurement) {
+        LOG.debug("New measurement: " + measurement);
+
+        String mac = measurement.getMac();
+        String name = Optional.ofNullable(measurement.getName()).orElse(mac);
+        String dataFormat = Optional.ofNullable(measurement.getDataFormat())
+            .map(String::valueOf).orElse("unknown");
+
+        prometheusExportedCount.labels(mac, name, dataFormat).inc();
+
+        rssi.labels(mac, name, dataFormat).set(measurement.getRssi());
+        temperature.labels(mac, name, dataFormat).set(measurement.getTemperature());
+        humidity.labels(mac, name, dataFormat).set(measurement.getHumidity());
+        pressure.labels(mac, name, dataFormat).set(measurement.getPressure());
+        accelerationX.labels(mac, name, dataFormat).set(measurement.getAccelerationX());
+        accelerationY.labels(mac, name, dataFormat).set(measurement.getAccelerationY());
+        accelerationZ.labels(mac, name, dataFormat).set(measurement.getAccelerationZ());
+        batteryVoltage.labels(mac, name, dataFormat).set(measurement.getBatteryVoltage());
+        txPower.labels(mac, name, dataFormat).set(measurement.getTxPower());
+
+        updateCounter(measurementSequenceNumber.labels(mac, name, dataFormat),
+            measurement.getMeasurementSequenceNumber());
+        updateCounter(movementCounter.labels(mac, name, dataFormat),
+            measurement.getMovementCounter());
+
+        accelerationTotal.labels(mac, name, dataFormat).set(measurement.getAccelerationTotal());
+        accelerationAngleFromX.labels(mac, name, dataFormat).set(measurement.getAccelerationAngleFromX());
+        accelerationAngleFromY.labels(mac, name, dataFormat).set(measurement.getAccelerationAngleFromY());
+        accelerationAngleFromZ.labels(mac, name, dataFormat).inc(measurement.getAccelerationAngleFromZ());
+        absoluteHumidity.labels(mac, name, dataFormat).set(measurement.getAbsoluteHumidity());
+        dewPoint.labels(mac, name, dataFormat).set(measurement.getDewPoint());
+        equilibriumVaporPressure.labels(mac, name, dataFormat).set(measurement.getEquilibriumVaporPressure());
+        airDensity.labels(mac, name, dataFormat).set(measurement.getAirDensity());
+
+        lastUpdate.labels(mac, name, dataFormat).setToCurrentTime();
+    }
+
+    /**
+     * Updates a {@link Counter} to reflect a value changed in an upstream value that claims to be a counter. This is
+     * like calling {@code set} on a Counter that only has {@code inc}. If the new value is less than the current value
+     * of the counter, the update is dropped.
+     */
+    private static void updateCounter(Counter.Child counter, Integer newValue) {
+        counter.inc(Math.max(0, newValue - (int) counter.get()));
+    }
+
+    @Override
+    public void close() {
+        httpServer.stop();
+    }
+}


### PR DESCRIPTION
This adds support to export measurements to Prometheus.

Whereas currently the collector supports writing measurements into a database, this Prometheus exporter pretends to be a database by writing measurements into counters. These are exported over HTTP in the normal pattern, to be scraped by a Prometheus server.