### PR TITLE
Adds a configurable "receiver" tag along each influxdb (#54)

### DIFF
--- a/ruuvi-collector.properties.example
+++ b/ruuvi-collector.properties.example
@@ -49,6 +49,10 @@
 # dummy           = Logs the measurements to the log rather than sending them anywhere, feasible for testing and development
 #storage.method=influxdb
 
+# A receiver identifier to tag values written by this instance to influxdb.
+# You could put in e.g. your host name or bluetooth receiver MAC here.
+#receiver=
+
 # Values to store, the collector is capable of calculating additional values from the values received from a tag, for example absolute humidity and dew point
 # Valid values "raw", "extended", "whitelist", "blacklist":
 # raw       = Save only the raw values received from the tag. Ignores the storage.values.list property.

--- a/src/main/java/fi/tkgwf/ruuvi/bean/EnhancedRuuviMeasurement.java
+++ b/src/main/java/fi/tkgwf/ruuvi/bean/EnhancedRuuviMeasurement.java
@@ -42,6 +42,10 @@ public class EnhancedRuuviMeasurement extends RuuviMeasurement {
      */
     private String mac;
     /**
+     * Arbitrary string associated with the receiver.
+     */
+    private String receiver;
+    /**
      * The RSSI at the receiver
      */
     private Integer rssi;
@@ -102,6 +106,14 @@ public class EnhancedRuuviMeasurement extends RuuviMeasurement {
         this.mac = mac;
     }
     
+    public String getReceiver() {
+        return receiver;
+    }
+
+    public void setReceiver(String receiver) {
+        this.receiver = receiver;
+    }
+
     public Integer getRssi() {
         return rssi;
     }
@@ -180,6 +192,7 @@ public class EnhancedRuuviMeasurement extends RuuviMeasurement {
                 + "time=" + time 
                 + ", name=" + name 
                 + ", mac=" + mac 
+                + ", receiver=" + receiver 
                 + ", rssi=" + rssi 
                 + ", accelerationTotal=" + accelerationTotal 
                 + ", accelerationAngleFromX=" + accelerationAngleFromX 

--- a/src/main/java/fi/tkgwf/ruuvi/config/Config.java
+++ b/src/main/java/fi/tkgwf/ruuvi/config/Config.java
@@ -64,6 +64,7 @@ public abstract class Config {
     private static Predicate<String> filterMode;
     private static final Set<String> FILTER_MACS = new HashSet<>();
     private static final Map<String, String> TAG_NAMES = new HashMap<>();
+    private static String receiver = ""; // used to tag received values with an identifier associated to this service
     private static String[] scanCommand;
     private static String[] dumpCommand;
     private static DBConnection dbConnection;
@@ -147,6 +148,7 @@ public abstract class Config {
         influxDbFieldFilter = createInfluxDbFieldFilter();
         filterMode = parseFilterMode(props);
         FILTER_MACS.addAll(parseFilterMacs(props));
+        receiver = props.getProperty("receiver", "");
         scanCommand = props.getProperty("command.scan", DEFAULT_SCAN_COMMAND).split(" ");
         dumpCommand = props.getProperty("command.dump", DEFAULT_DUMP_COMMAND).split(" ");
         influxRetentionPolicy = props.getProperty("influxRetentionPolicy", influxRetentionPolicy);
@@ -436,6 +438,10 @@ public abstract class Config {
 
     public static boolean isAllowedMAC(String mac) {
         return mac != null && filterMode.test(mac);
+    }
+
+    public static String getReceiver() {
+        return receiver;
     }
 
     public static String[] getScanCommand() {

--- a/src/main/java/fi/tkgwf/ruuvi/handler/BeaconHandler.java
+++ b/src/main/java/fi/tkgwf/ruuvi/handler/BeaconHandler.java
@@ -39,6 +39,7 @@ public class BeaconHandler {
         enhancedMeasurement.setMac(hciData.mac);
         enhancedMeasurement.setRssi(hciData.rssi);
         enhancedMeasurement.setName(Config.getTagName(hciData.mac));
+        enhancedMeasurement.setReceiver(Config.getReceiver());
         return Optional.of(enhancedMeasurement);
     }
 }

--- a/src/main/java/fi/tkgwf/ruuvi/utils/InfluxDBConverter.java
+++ b/src/main/java/fi/tkgwf/ruuvi/utils/InfluxDBConverter.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.StringUtils;
 import org.influxdb.dto.BatchPoints;
 import org.influxdb.dto.Point;
 import java.util.function.Function;
@@ -58,6 +59,9 @@ public class InfluxDBConverter {
         }
         if (measurement.getDataFormat() != null) {
             p.tag("dataFormat", String.valueOf(measurement.getDataFormat()));
+        }
+        if (StringUtils.isNotBlank(measurement.getReceiver())) {
+            p.tag("receiver", measurement.getReceiver());
         }
         if (measurement.getTime() != null) {
             p.time(measurement.getTime(), TimeUnit.MILLISECONDS);


### PR DESCRIPTION
By default the receiver tag is an empty string, in which case the
values will not be tagged. If configured (by the "receiver" property
int ruuvi-collector.properties file), then each value sent to influxdb
will have the value in the "receiver" tag.

This allows distinguishing values when the same database is being used
by multiple receivers and allows analyzing packet loss and RSSI
differences, and eventually forming a black/whitelist to minimize
duplicate data in the backing database.