### PR TITLE
Update log4j to address CVE-2021-44228

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,13 +44,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.11.1</version>
+            <version>2.15.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.2</version>
+            <version>2.15.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR updates the log4j dependency in order to address CVE-2021-44228.

As far as I understand, exploiting the vulnerability would require physical proximity. Therefore, the vulnerability is not as critical as in many other pieces of software, but it might make sense to address this just to be on the safe side.