### PR TITLE
Unclean exit on database connection loss #68

### DIFF
--- a/ruuvi-collector.properties.example
+++ b/ruuvi-collector.properties.example
@@ -88,6 +88,11 @@
 # Use batch mode, improved performance at the cost of increased delay for measurements to show up. Does not affect the timestamps.
 #influxBatch=true
 
+# Exit when InfluxDB connection is lost so systemd can take action (disabled by
+# default for backward compatibility, requires influxBatch to be false to take
+# effect due to limitations of the InfluxDB library)
+#exitOnInfluxDBIOException=false
+
 # Maximum number of datapoints and maximum time waited in milliseconds before sending a batch. Has no effect if batch mode disabled.
 #influxBatchMaxSize=2000
 #influxBatchMaxTime=100

--- a/src/main/java/fi/tkgwf/ruuvi/Main.java
+++ b/src/main/java/fi/tkgwf/ruuvi/Main.java
@@ -14,6 +14,7 @@ import java.io.InputStreamReader;
 import java.util.Arrays;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
+import org.influxdb.InfluxDBIOException;
 
 public class Main {
 
@@ -108,6 +109,9 @@ public class Main {
                             healthy = true;
                         }
                     }
+                } catch (InfluxDBIOException ex) {
+                    LOG.error("Database connection lost while attempting to save measurements to InfluxDB", ex);
+                    return false;
                 } catch (Exception ex) {
                     if (latestMAC != null) {
                         LOG.warn("Uncaught exception while handling measurements from MAC address \"" + latestMAC + "\", if this repeats and this is not a Ruuvitag, try blacklisting it", ex);

--- a/src/main/java/fi/tkgwf/ruuvi/Main.java
+++ b/src/main/java/fi/tkgwf/ruuvi/Main.java
@@ -111,7 +111,9 @@ public class Main {
                     }
                 } catch (InfluxDBIOException ex) {
                     LOG.error("Database connection lost while attempting to save measurements to InfluxDB", ex);
-                    return false;
+                    if (Config.exitOnInfluxDBIOException()) {
+                        return false;
+                    }
                 } catch (Exception ex) {
                     if (latestMAC != null) {
                         LOG.warn("Uncaught exception while handling measurements from MAC address \"" + latestMAC + "\", if this repeats and this is not a Ruuvitag, try blacklisting it", ex);
@@ -123,9 +125,7 @@ public class Main {
             }
         } catch (IOException ex) {
             LOG.error("Uncaught exception while reading measurements", ex);
-            if (Config.exitOnInfluxDBIOException()) {
-                return false;
-            }
+            return false;
         }
         return healthy;
     }

--- a/src/main/java/fi/tkgwf/ruuvi/Main.java
+++ b/src/main/java/fi/tkgwf/ruuvi/Main.java
@@ -123,7 +123,9 @@ public class Main {
             }
         } catch (IOException ex) {
             LOG.error("Uncaught exception while reading measurements", ex);
-            return false;
+            if (Config.exitOnInfluxDBIOException()) {
+                return false;
+            }
         }
         return healthy;
     }

--- a/src/main/java/fi/tkgwf/ruuvi/config/Config.java
+++ b/src/main/java/fi/tkgwf/ruuvi/config/Config.java
@@ -54,6 +54,7 @@ public abstract class Config {
     private static String influxRetentionPolicy;
     private static boolean influxGzip;
     private static boolean influxBatch;
+    private static boolean exitOnInfluxDBIOException;
     private static int influxBatchMaxSize;
     private static int influxBatchMaxTimeMs;
     private static long measurementUpdateLimit;
@@ -100,6 +101,7 @@ public abstract class Config {
         influxRetentionPolicy = "autogen";
         influxGzip = true;
         influxBatch = true;
+        exitOnInfluxDBIOException = false;
         influxBatchMaxSize = 2000;
         influxBatchMaxTimeMs = 100;
         measurementUpdateLimit = 9900;
@@ -154,6 +156,7 @@ public abstract class Config {
         influxRetentionPolicy = props.getProperty("influxRetentionPolicy", influxRetentionPolicy);
         influxGzip = parseBoolean(props, "influxGzip", influxGzip);
         influxBatch = parseBoolean(props, "influxBatch", influxBatch);
+        exitOnInfluxDBIOException = parseBoolean(props, "exitOnInfluxDBIOException", exitOnInfluxDBIOException);
         influxBatchMaxSize = parseInteger(props, "influxBatchMaxSize", influxBatchMaxSize);
         influxBatchMaxTimeMs = parseInteger(props, "influxBatchMaxTime", influxBatchMaxTimeMs);
         limitingStrategy = parseLimitingStrategy(props);
@@ -422,6 +425,10 @@ public abstract class Config {
 
     public static boolean isInfluxBatch() {
         return influxBatch;
+    }
+
+    public static boolean exitOnInfluxDBIOException() {
+        return exitOnInfluxDBIOException;
     }
 
     public static int getInfluxBatchMaxSize() {


### PR DESCRIPTION
When in non-batch mode, an exception can be thrown by the InfluxDB library.  This change will catch that exception and cause RuuviCollector to exit with a non-zero return code.

This defers handling the problem to the supervisory system (e.g., systemd).  It could restart the service any number of times, send off notifications, possibly restart the database service, or whatever is appropriate in each specific deployment.