### PR TITLE
lescan watchdog service

### DIFF
--- a/service-setup/lescan_watchdog.service
+++ b/service-setup/lescan_watchdog.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Make sure lescan is working
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/lescan_watchdog.sh

--- a/service-setup/lescan_watchdog.sh
+++ b/service-setup/lescan_watchdog.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+if [ `journalctl -eu lescan --since "1 minute ago" | wc -l` -le 2 ]; then
+	systemctl restart lescan
+fi

--- a/service-setup/lescan_watchdog.timer
+++ b/service-setup/lescan_watchdog.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Check in every 15 minutes to make sure lescan is still working
+
+[Timer]
+OnCalendar=*:0/15
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/service-setup/setup.sh
+++ b/service-setup/setup.sh
@@ -109,3 +109,8 @@ fi
 cp service-setup/lescan.service service-setup/ruuvicollector.service /etc/systemd/system
 systemctl enable lescan ruuvicollector
 systemctl start lescan ruuvicollector
+# And the watchdog service
+cp service-setup/lescan_watchdog.service service-setup/lescan_watchdog.timer /etc/systemd/system
+mv service-setup/lescan_watchdog.sh /usr/local/bin/
+sudo systemctl enable lescan_watchdog.timer
+sudo systemctl start lescan_watchdog.timer


### PR DESCRIPTION
I found that sometimes data suddenly stops coming into RuuviCollector despite lescan and hcidump running as expected. Looking at the output of lescan, I can see that it just stops picking things up.  There aren't any errors in the logs, so I don't know the root cause (hardware issues, kernel, lescan itself, etc.), just that it is happening.  Restarting the lescan process gets it going again.

To work around this, I created a watchdog service that will watch for the lescan service to have not put out any log messages for a while and when that happens it'll restart the lescan service. This way the sensor data continues to be collected without any manual intervention.

If there is a system out there that doesn't have this problem, or if the issue is fixed or worked around in lescan itself in the future, the watchdog will not do any harm.