### PR TITLE
Minor setup.sh improvements

### DIFF
--- a/service-setup/setup.sh
+++ b/service-setup/setup.sh
@@ -111,6 +111,6 @@ systemctl enable lescan ruuvicollector
 systemctl start lescan ruuvicollector
 # And the watchdog service
 cp service-setup/lescan_watchdog.service service-setup/lescan_watchdog.timer /etc/systemd/system
-mv service-setup/lescan_watchdog.sh /usr/local/bin/
+cp service-setup/lescan_watchdog.sh /usr/local/bin/
 sudo systemctl enable lescan_watchdog.timer
 sudo systemctl start lescan_watchdog.timer

--- a/service-setup/setup.sh
+++ b/service-setup/setup.sh
@@ -105,6 +105,11 @@ if [ -n "$DB_NAME" ]; then
         /opt/ruuvicollector/ruuvi-collector.properties
 fi
 
+# Copy ruuvi-names.properties if it exists (and does not exist in the destination)
+if [ ! -f /opt/ruuvicollector/ruuvi-names.properties ] && [ -f ruuvi-names.properties ]; then
+    cp ruuvi-names.properties /opt/ruuvicollector
+fi
+
 # Now to set up the services
 cp service-setup/lescan.service service-setup/ruuvicollector.service /etc/systemd/system
 systemctl enable lescan ruuvicollector


### PR DESCRIPTION
This PR introduces two minor `setup.sh` improvements:

1. copy the `lescan_watchdog.sh` file to `/usr/local/bin` instead of moving it. This makes it possible to run the script successfully more than once.
2. Copy the `ruuvi-names.properties` file if it exists (and does not exist in the destination directory). This makes it easier to use your existing RuuviTag names in the installed service.

Thanks for the great piece of software by the way! Hope these make it even better 🙂