### PR TITLE
Reduce lescan.service journalctl logging

### DIFF
--- a/service-setup/lescan.service
+++ b/service-setup/lescan.service
@@ -6,6 +6,11 @@ Type=simple
 # Ensure the bluetooth interface is in a good state prior to starting the scan
 ExecStartPre=/usr/bin/hciconfig reset
 ExecStart=/usr/bin/hcitool lescan --duplicates --passive
+# lescan prints each detected advert to stdout, which produces a lot of log
+# to the journal. RuuviCollector does not need the log, so throw away the output,
+# but do print errors.
+StandardOutput=null
+StandardError=journal
 Restart=always
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The lescan service produces a lot of log to the journal, as `hcitool lescan` dumps each advert to the standard output. This is suboptimal for e.g. a Raspberry Pi, which is often running off an SD card where excessive writes are undesirable.

As RuuviCollector does not use the output (lescan just needs to be running so that `hcitool dump` is updated, if I understood correctly), this commit changes the lescan.service unit to redirect the service's stdout to null. `stderr` is still written to journal.

If unset, `StandardOutput` and `StandardError` derive their values from the `DefaultStandardOutput` and `DefaultStandardError` systemd configs (configurable by e.g. [`/etc/systemd/system.conf`](https://www.freedesktop.org/software/systemd/man/latest/systemd-system.conf.html)). By default these are `journal` and `inherit`, which means `StandardOutput` is journal and `StandardError` uses the same as `StandardOutput`.

Users may have configured their systemd to have different defaults, in the case of which it may be preferable to include these changed lines as comments that the user can uncomment when installing, or maybe just pipe stdout to `/dev/null` in `ExecStart`.